### PR TITLE
Treat long counter as if it were an 8-byte buffer

### DIFF
--- a/OtpCore/HotpAuthenticator.cs
+++ b/OtpCore/HotpAuthenticator.cs
@@ -33,15 +33,11 @@ namespace Petrsnd.OtpCore
         {
             if (_uri.Counter == null)
                 throw new Exception("Counter was not set");
-            if (_uri.Counter.Value + 1 < 0)
-                throw new Exception("Incrementing counter resulted in roll over to negative number");
-            SetCounter(_uri.Counter.Value + 1);
+            SetCounter(unchecked(_uri.Counter.Value + 1));
         }
 
         public void SetCounter(long counter)
         {
-            if (counter < 0)
-                throw new ArgumentException("Counter must not be negative", nameof(counter));
             // Side effect -- modifies the underlying URI and previous formatting is overridden
             _uri = new OtpAuthUri(OtpType.Hotp, _uri.SecretBuf, _uri.Account, _uri.Issuer, counter, _uri.Algorithm,
                 _uri.Digits);

--- a/OtpCore/OtpAuthUri.cs
+++ b/OtpCore/OtpAuthUri.cs
@@ -40,9 +40,6 @@ namespace Petrsnd.OtpCore
             
             if (Type == OtpType.Hotp)
             {
-                if (counterOrPeriod < 0)
-                    throw new ArgumentOutOfRangeException(nameof(counterOrPeriod), counterOrPeriod,
-                        "Counter is a signed integer but must not be negative");
                 Counter = counterOrPeriod;
                 uriString += $"&counter={Counter}&digits={Digits}";
             }
@@ -165,8 +162,6 @@ namespace Petrsnd.OtpCore
             {
                 if (!long.TryParse(Parameters["counter"], out var counter))
                     throw new ArgumentException("URI counter query parameter must be numeric", nameof(uri));
-                if (counter < 0)
-                    throw new ArgumentException("Counter must not be negative", nameof(uri));
                 Counter = counter;
             }
 

--- a/OtpCore/Utilities.cs
+++ b/OtpCore/Utilities.cs
@@ -27,18 +27,9 @@ namespace Petrsnd.OtpCore
 
         public static byte[] CounterToBuffer(long counter)
         {
-            if (counter < 0)
-                throw new ArgumentOutOfRangeException(nameof(counter), counter,
-                    "Counter is a signed integer but must not be negative");
-            var counterBytes = new List<byte>();
-            while (counter > 0)
-            {
-                counterBytes.Add((byte)(counter & 0xff));
-                counter >>= 8;
-            }
-            while (counterBytes.Count < 8)
-                counterBytes.Add(0);
-            counterBytes.Reverse();
+            var counterBytes = BitConverter.GetBytes(counter);
+            if (BitConverter.IsLittleEndian)
+                return counterBytes.Reverse().ToArray();
             return counterBytes.ToArray();
         }
 

--- a/TestOtpCore/UtilitiesTest.cs
+++ b/TestOtpCore/UtilitiesTest.cs
@@ -21,11 +21,7 @@ namespace Petrsnd.OtpCore.Test
             Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x27, 0xBC, 0x86, 0xAA }, Utilities.CounterToBuffer(666666666));
             // Additional value larger than 32-bits
             Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x05, 0x2D, 0xC7, 0x47, 0xB1 }, Utilities.CounterToBuffer(22242871217));
-
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                Utilities.CounterToBuffer(-1000);
-            });
+            Assert.Equal(new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, Utilities.CounterToBuffer(unchecked(long.MaxValue + 1)));
         }
 
         [Fact]


### PR DESCRIPTION
This is better.  Don't have to worry about checking for negative counters which aren't disallowed in the spec.  The spec says 8-byte it is an 8-byte integer.  Using a ulong isn't a good option because the TOTP implementation use HOTP under the covers and Unix time is signed for historical reasons.  You start to run into a lot of casting problems when converting a Unix time to a counter if you try to make counters unsigned.  It is better just to do the arithmetic with signed integers and calculate the buffer as if it were unsigned by just grabbing the bytes.  I explicitly removed bounds checking in the unlikely case that long.MaxValue is incremented which results in the correct buffer but does strange things arithmetically.  There are unit tests to catch a platform compiling this code that behaves differently than what is expected by this library.