### PR TITLE
Issue 22: Malformed URI throws Null Reference Exception

### DIFF
--- a/OtpCore/OtpAuthUri.cs
+++ b/OtpCore/OtpAuthUri.cs
@@ -101,6 +101,9 @@ namespace Petrsnd.OtpCore
             var nameValues = HttpUtility.ParseQueryString(Uri.Query);
             foreach (var key in nameValues.Keys)
             {
+                if (key == null)
+                    throw new ArgumentException("URI parameter string is malformed.");
+
                 Parameters[key.ToString().ToLower()] = nameValues[key.ToString()];
             }
 

--- a/TestOtpCore/OtpAuthUriTest.cs
+++ b/TestOtpCore/OtpAuthUriTest.cs
@@ -261,6 +261,13 @@ namespace Petrsnd.OtpCore.Test
         }
 
         [Fact]
+        public void GitHubIssueNo22()
+        {
+            // missing params should throw.
+            Assert.Throws<ArgumentException>(() => new OtpAuthUri("otpauth://totp/Test?&issuer=Test"));
+        }
+
+        [Fact]
         public void CommonAuthenticatorsGoogle()
         {
             // Google Authenticator Sample


### PR DESCRIPTION
Add check for null while iterating over URI params. Update Unit Tests.